### PR TITLE
Change 'vars' to 'filter' in erbsScanner.R

### DIFF
--- a/R/erbsScanner.R
+++ b/R/erbsScanner.R
@@ -7,7 +7,7 @@ txdb = TxDb.Hsapiens.UCSC.hg19.knownGene
 eid = select(Homo.sapiens, keys=sym, keytype="SYMBOL", columns="ENTREZID")
 allg = genes(txdb) # multistrand are dropped
 must_concat = FALSE
-curgAddr = genes(txdb, single.strand=FALSE, vals=list(gene_id=eid$ENTREZID) )[[1]]
+curgAddr = genes(txdb, single.strand=FALSE, filter=list(gene_id=eid$ENTREZID) )[[1]]
 if (length(curgAddr)>1) {
    must_concat = TRUE
    curgAddr$gene_id = eid$ENTREZID


### PR DESCRIPTION
The function erbsScanner() has an error.
```
Error: The 'vals' argument has been renamed 'filter'. Please use the
  'filter' argument instead.
```
Change 'vars' to 'filter' in 'curgAddr = genes(txdb, single.strand=FALSE, vars=list(gene_id=eid$ENTREZID) )[[1]]'.
Then it works well.